### PR TITLE
Add Application.ProcessMessages when the StatusBar is updated.

### DIFF
--- a/source/cmain.pas
+++ b/source/cmain.pas
@@ -1348,6 +1348,7 @@ begin
   else
     Statusbar.SimpleText := '';
   Statusbar.Update;
+  Application.ProcessMessages;
 end;
 
 function CreateIni: TCustomIniFile;


### PR DESCRIPTION
When pushing the update button, all the messages on the status bar will not show since the main thread is busy on the button's action.

With Application.ProcessMessages the messages will all show.